### PR TITLE
Fix z-level rendering for dot style markers

### DIFF
--- a/src/main/java/com/pathmarker/PathMarkerOverlay.java
+++ b/src/main/java/com/pathmarker/PathMarkerOverlay.java
@@ -144,7 +144,7 @@ public class PathMarkerOverlay extends Overlay
         {
             return;
         }
-        final Point screenPoint = Perspective.localToCanvas(client, lp, client.getTopLevelWorldView().getPlane());
+        final Point screenPoint = Perspective.localToCanvas(client, lp, client.getLocalPlayer().getWorldView().getPlane());
 
         if (screenPoint != null)
         {

--- a/src/main/java/com/pathmarker/PathMarkerOverlay.java
+++ b/src/main/java/com/pathmarker/PathMarkerOverlay.java
@@ -144,7 +144,7 @@ public class PathMarkerOverlay extends Overlay
         {
             return;
         }
-        final Point screenPoint = Perspective.localToCanvas(client, lp, 0);
+        final Point screenPoint = Perspective.localToCanvas(client, lp, client.getTopLevelWorldView().getPlane());
 
         if (screenPoint != null)
         {


### PR DESCRIPTION
The z-level for the dot style markers was hardcoded to `0`. This PR fixes that by grabbing the current z-index of the top level world when rendering the dot.