### PR TITLE
Additional null checks to prevent crashes

### DIFF
--- a/src/main/java/com/pathmarker/PathMarkerOverlay.java
+++ b/src/main/java/com/pathmarker/PathMarkerOverlay.java
@@ -35,6 +35,10 @@ public class PathMarkerOverlay extends Overlay
     @Override
     public Dimension render(Graphics2D graphics)
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return null;
+        }
         if ((config.hoverPathDisplaySetting() != PathMarkerConfig.PathDisplaySetting.NEVER)
                 && (config.activePathDisplaySetting() == PathMarkerConfig.PathDisplaySetting.NEVER || !plugin.isPathActive() || !config.drawOnlyIfNoActivePath())
                 && (plugin.isKeyDisplayHoverPath() || config.hoverPathDisplaySetting() == PathMarkerConfig.PathDisplaySetting.ALWAYS))

--- a/src/main/java/com/pathmarker/PathMarkerPlugin.java
+++ b/src/main/java/com/pathmarker/PathMarkerPlugin.java
@@ -227,6 +227,10 @@ public class PathMarkerPlugin extends Plugin
 
     private Pair<List<WorldPoint>, Boolean> pathToHover()
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return null;
+        }
         MenuEntry[] menuEntries = client.getMenuEntries();
         if (menuEntries.length == 0)
         {
@@ -425,6 +429,10 @@ public class PathMarkerPlugin extends Plugin
     {
         pathTiles.clear();
         middlePathTiles.clear();
+        if (client.getLocalPlayer() == null || client.getTopLevelWorldView() == null)
+        {
+            return;
+        }
         WorldArea currentWA = client.getLocalPlayer().getWorldArea();
         if (currentWA == null || checkpointWPs == null || checkpointWPs.size() == 0)
         {
@@ -447,6 +455,13 @@ public class PathMarkerPlugin extends Plugin
             }
             int dx = Integer.signum(cpTileWP.getX() - currentWA.getX());
             int dy = Integer.signum(cpTileWP.getY() - currentWA.getY());
+            if (!WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX(), currentWA.getY()) ||
+                !WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX() + dx, currentWA.getY() + dy) ||
+                (dx != 0 && !WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX() + dx, currentWA.getY())) ||
+                (dy != 0 && !WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX(), currentWA.getY() + dy)))
+            {
+                break;
+            }
             WorldArea finalCurrentWA = currentWA;
             boolean movementCheck = currentWA.canTravelInDirection(client.getTopLevelWorldView(), dx, dy, (worldPoint -> {
                 WorldPoint worldPoint1 = new WorldPoint(finalCurrentWA.getX() + dx, finalCurrentWA.getY(), client.getLocalPlayer().getWorldView().getPlane());
@@ -543,6 +558,10 @@ public class PathMarkerPlugin extends Plugin
 
     private void updateCheckpointTiles()
     {
+        if (client.getLocalPlayer() == null || client.getTopLevelWorldView() == null)
+        {
+            return;
+        }
         if (lastTickWorldLocation == null || activeCheckpointWPs.isEmpty())
         {
             return;
@@ -573,6 +592,13 @@ public class PathMarkerPlugin extends Plugin
             }
             int dx = Integer.signum(cpTileWP.getX() - currentWA.getX());
             int dy = Integer.signum(cpTileWP.getY() - currentWA.getY());
+            if (!WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX(), currentWA.getY()) ||
+                !WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX() + dx, currentWA.getY() + dy) ||
+                (dx != 0 && !WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX() + dx, currentWA.getY())) ||
+                (dy != 0 && !WorldPoint.isInScene(client.getTopLevelWorldView(), currentWA.getX(), currentWA.getY() + dy)))
+            {
+                break;
+            }
             WorldArea finalCurrentWA = currentWA;
             boolean movementCheck = currentWA.canTravelInDirection(client.getTopLevelWorldView(), dx, dy, (worldPoint -> {
                 WorldPoint worldPoint1 = new WorldPoint(finalCurrentWA.getX() + dx, finalCurrentWA.getY(), client.getLocalPlayer().getWorldView().getPlane());
@@ -688,6 +714,10 @@ public class PathMarkerPlugin extends Plugin
 
     private void updateNpcBlockings()
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return;
+        }
         List<NPC> npcs = client.getLocalPlayer().getWorldView().npcs()
                 .stream()
                 .collect(Collectors.toCollection(ArrayList::new));
@@ -731,6 +761,10 @@ public class PathMarkerPlugin extends Plugin
 
     TileItem findTileItem(int x, int y, int id)
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return null;
+        }
         Scene scene = client.getLocalPlayer().getWorldView().getScene();
         Tile[][][] tiles = scene.getTiles();
         Tile tile = tiles[client.getLocalPlayer().getWorldView().getPlane()][x][y];
@@ -755,6 +789,10 @@ public class PathMarkerPlugin extends Plugin
 
     TileObject findTileObject(int x, int y, int id)
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return null;
+        }
         Scene scene = client.getLocalPlayer().getWorldView().getScene();
         Tile[][][] tiles = scene.getTiles();
         Tile tile = tiles[client.getLocalPlayer().getWorldView().getPlane()][x][y];
@@ -834,6 +872,10 @@ public class PathMarkerPlugin extends Plugin
 
     private Point minimapToScenePoint()
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return null;
+        }
         if (client.getMenuEntries().length != 1 || lastMouseCanvasPosition == null)
         {
             // Minimap hovering doesn't add menu entries other than the default "cancel"
@@ -895,6 +937,10 @@ public class PathMarkerPlugin extends Plugin
     @Subscribe
     public void onMenuOptionClicked(MenuOptionClicked event)
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return;
+        }
         switch (event.getMenuAction())
         {
             case EXAMINE_ITEM_GROUND:
@@ -1088,6 +1134,10 @@ public class PathMarkerPlugin extends Plugin
     @Subscribe
     public void onClientTick(ClientTick event)
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return;
+        }
         if (calcTilePathOnNextClientTick)
         {
             Tile selectedSceneTile = client.getLocalPlayer().getWorldView().getSelectedSceneTile();
@@ -1195,6 +1245,10 @@ public class PathMarkerPlugin extends Plugin
     @Subscribe
     public void onGameTick(GameTick event)
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return;
+        }
         LocalPoint localDestinationLocation = client.getLocalDestinationLocation();
         if (localDestinationLocation != null && pathActive && activePathFound)
         {

--- a/src/main/java/com/pathmarker/PathMarkerPlugin.java
+++ b/src/main/java/com/pathmarker/PathMarkerPlugin.java
@@ -767,7 +767,12 @@ public class PathMarkerPlugin extends Plugin
         }
         Scene scene = client.getLocalPlayer().getWorldView().getScene();
         Tile[][][] tiles = scene.getTiles();
-        Tile tile = tiles[client.getLocalPlayer().getWorldView().getPlane()][x][y];
+        int plane = client.getLocalPlayer().getWorldView().getPlane();
+        if (plane < 0 || plane >= tiles.length || x < 0 || x >= tiles[plane].length || y < 0 || y >= tiles[plane][x].length)
+        {
+            return null;
+        }
+        Tile tile = tiles[plane][x][y];
         if (tile == null)
         {
             return null;
@@ -795,7 +800,12 @@ public class PathMarkerPlugin extends Plugin
         }
         Scene scene = client.getLocalPlayer().getWorldView().getScene();
         Tile[][][] tiles = scene.getTiles();
-        Tile tile = tiles[client.getLocalPlayer().getWorldView().getPlane()][x][y];
+        int plane = client.getLocalPlayer().getWorldView().getPlane();
+        if (plane < 0 || plane >= tiles.length || x < 0 || x >= tiles[plane].length || y < 0 || y >= tiles[plane][x].length)
+        {
+            return null;
+        }
+        Tile tile = tiles[plane][x][y];
         if (tile != null)
         {
             for (GameObject gameObject : tile.getGameObjects())

--- a/src/main/java/com/pathmarker/PathMinimapMarkerOverlay.java
+++ b/src/main/java/com/pathmarker/PathMinimapMarkerOverlay.java
@@ -35,6 +35,10 @@ public class PathMinimapMarkerOverlay extends Overlay
     @Override
     public Dimension render(Graphics2D graphics)
     {
+        if (client.getLocalPlayer() == null)
+        {
+            return null;
+        }
         double angle = client.getCameraYawTarget() * 0.0030679615D;
         Widget minimapDrawWidget;
         if (client.isResized())

--- a/src/main/java/com/pathmarker/Pathfinder.java
+++ b/src/main/java/com/pathmarker/Pathfinder.java
@@ -39,9 +39,9 @@ public class Pathfinder
         {
             return null;
         }
-        int z = client.getLocalPlayer().getWorldView().getPlane();
+        int z = player.getWorldView().getPlane();
 
-        CollisionData[] collisionData = client.getLocalPlayer().getWorldView().getCollisionMaps();
+        CollisionData[] collisionData = player.getWorldView().getCollisionMaps();
         if (collisionData == null)
         {
             return null;
@@ -56,7 +56,7 @@ public class Pathfinder
                 distances[i][j] = Integer.MAX_VALUE;
             }
         }
-        LocalPoint playerTrueTileLocalPoint = LocalPoint.fromWorld(client.getLocalPlayer().getWorldView(), player.getWorldLocation());
+        LocalPoint playerTrueTileLocalPoint = LocalPoint.fromWorld(player.getWorldView(), player.getWorldLocation());
         if (playerTrueTileLocalPoint == null)
         {
             return null;
@@ -267,7 +267,7 @@ public class Pathfinder
         }
 
         int checkpointTileNumber = 1;
-        Tile[][][] tiles = client.getLocalPlayer().getWorldView().getScene().getTiles();
+        Tile[][][] tiles = player.getWorldView().getScene().getTiles();
         List<WorldPoint> checkpointWPs = new ArrayList<>();
         while (index-- > 0)
         {


### PR DESCRIPTION
I've experienced some crashes so this PR adds some additional null checks which should prevent them in the future.
#
```java
2026-06-21 18:51:15 CEST [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: Cannot invoke "net.runelite.api.Player.getWorldView()" because the return value of "net.runelite.api.Client.getLocalPlayer()" is null
	at com.pathmarker.PathMarkerPlugin.onClientTick(PathMarkerPlugin.java:1112)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:217)
	at pi.xn(pi.java:7877)
	at pi.gg(pi.java:26)
	at client.io(client.java:10768)
	at client.il(client.java:9501)
	at tf.ahj(tf.java:442)
	at tf.bh(tf.java)
	at tf.run(tf.java:2522)
	at java.base/java.lang.Thread.run(Unknown Source)
2026-06-21 18:51:15 CEST [Client] INFO  n.r.taskstracker.TasksTrackerPlugin - processVarpAndUpdateTasks: all
2026-06-21 21:15:55 CEST [Client] INFO  n.r.taskstracker.TasksTrackerPlugin - processVarpAndUpdateTasks: all
2026-06-21 21:16:03 CEST [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: Cannot invoke "net.runelite.api.coords.LocalPoint.getSceneX()" because "lp" is null
	at net.runelite.api.coords.WorldArea.canTravelInDirection(WorldArea.java:274)
	at com.pathmarker.PathMarkerPlugin.updateCheckpointTiles(PathMarkerPlugin.java:577)
	at com.pathmarker.PathMarkerPlugin.onGameTick(PathMarkerPlugin.java:1233)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:235)
	at client.ad(client.java:28463)
	at client.il(client.java)
	at tf.ahj(tf.java:442)
	at tf.bh(tf.java)
	at tf.run(tf.java:2522)
	at java.base/java.lang.Thread.run(Unknown Source)
```

```
2026-06-22 15:02:40 CEST [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: Cannot invoke "net.runelite.api.Player.getWorldView()" because the return value of "net.runelite.api.Client.getLocalPlayer()" is null
	at com.pathmarker.PathMarkerPlugin.onClientTick(PathMarkerPlugin.java:1112)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:217)
	at pi.xn(pi.java:7877)
	at pi.gg(pi.java:26)
	at client.io(client.java:10768)
	at client.il(client.java:9501)
	at tf.ahj(tf.java:442)
	at tf.bh(tf.java)
	at tf.run(tf.java:2522)
	at java.base/java.lang.Thread.run(Unknown Source)
```